### PR TITLE
Use blockquote for TL;DR inline note

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ Azure functions is an offering from Microsoft that allows you to create serverle
 <img src="https://github.com/Azure-Samples/functions-dotnet-migrating-console-apps/blob/master/HttpTriggerWithAuthz.PNG?raw=true" alt="Create an Http Trigger"></img> 
 
 # Adding Code
+> **TL;DR**  
 If you don't care about the details, just go to your function's "Your Files > Upload Files" (top right) and upload [the 3 files in the code sample](https://github.com/Azure-Samples/functions-dotnet-migrating-console-apps/tree/master/code) along with the .exe (and .dll's it requires)
---
+
 The following are steps that you should follow if you want to fimiliarinze yourself with the using Azure functions interface.
 
 1. Select the run.csx file under **View files**


### PR DESCRIPTION
I understand the reason the inline block is added but it really obstructed reading experience on the doc page. Here is proposal to use built-in blockquote for TLDR note

Thanks!

![image](https://user-images.githubusercontent.com/14539/33232236-c029bd36-d202-11e7-9026-d05e46272814.png)